### PR TITLE
SLING-7590 Set time-zone auto indention during JSON parse.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
         <url>https://gitbox.apache.org/repos/asf?p=sling-org-apache-sling-jcr-contentparser.git</url>
     </scm>
 
+    <properties>
+        <sling.java.version>8</sling.java.version>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/org/apache/sling/jcr/contentparser/impl/ParserHelper.java
+++ b/src/main/java/org/apache/sling/jcr/contentparser/impl/ParserHelper.java
@@ -18,21 +18,23 @@
  */
 package org.apache.sling.jcr.contentparser.impl;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.util.ISO8601;
+import org.apache.sling.jcr.contentparser.ParseException;
+import org.apache.sling.jcr.contentparser.ParserOptions;
+
 import java.lang.reflect.Array;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
+import java.util.TimeZone;
 import javax.json.JsonObject;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.jackrabbit.util.ISO8601;
-import org.apache.sling.jcr.contentparser.ParseException;
-import org.apache.sling.jcr.contentparser.ParserOptions;
 
 /**
  * Helper parsing logic based on parser options.
@@ -45,12 +47,12 @@ class ParserHelper {
     static final Locale DATE_FORMAT_LOCALE = Locale.US;
 
     private final ParserOptions options;
-    private final DateFormat calendarFormat;
+    private final DateTimeFormatter calendarFormat;
 
     public ParserHelper(ParserOptions options) {
         this.options = options;
         if (options.isDetectCalendarValues()) {
-            this.calendarFormat = new SimpleDateFormat(ECMA_DATE_FORMAT, DATE_FORMAT_LOCALE);
+            this.calendarFormat = DateTimeFormatter.ofPattern(ECMA_DATE_FORMAT, DATE_FORMAT_LOCALE);
         }
         else {
             this.calendarFormat = null;
@@ -76,12 +78,12 @@ class ParserHelper {
             // 2nd try: parse with ECMA date format which is used by Sling GET servlet
             calendar = Calendar.getInstance();
             try {
-                synchronized (calendarFormat) {
-                    Date date = calendarFormat.parse(value);
-                    calendar.setTime(date);
-                }
+                final OffsetDateTime offsetDateTime = OffsetDateTime.parse(value, calendarFormat);
+                final Instant instant = offsetDateTime.toInstant();
+                calendar.setTime(Date.from(instant));
+                calendar.setTimeZone(TimeZone.getTimeZone(offsetDateTime.getOffset()));
                 return calendar;
-            } catch (java.text.ParseException ex) {
+            } catch (DateTimeParseException ex) {
                 // ignore
             }
         }

--- a/src/test/java/org/apache/sling/jcr/contentparser/impl/JsonContentParserTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentparser/impl/JsonContentParserTest.java
@@ -119,8 +119,6 @@ public class JsonContentParserTest {
         Calendar calendar = (Calendar) props.get("dateISO8601String");
         assertNotNull(calendar);
 
-        calendar.setTimeZone(TimeZone.getTimeZone("GMT+2"));
-
         assertEquals(2014, calendar.get(Calendar.YEAR));
         assertEquals(4, calendar.get(Calendar.MONTH) + 1);
         assertEquals(22, calendar.get(Calendar.DAY_OF_MONTH));

--- a/src/test/java/org/apache/sling/jcr/contentparser/impl/ParserHelperTest.java
+++ b/src/test/java/org/apache/sling/jcr/contentparser/impl/ParserHelperTest.java
@@ -82,8 +82,6 @@ public class ParserHelperTest {
         Calendar value = underTest.tryParseCalendar("Tue Apr 22 2014 15:11:24 GMT+0200");
         assertNotNull(value);
 
-        value.setTimeZone(TimeZone.getTimeZone("GMT+2"));
-
         assertEquals(2014, value.get(Calendar.YEAR));
         assertEquals(4, value.get(Calendar.MONTH) + 1);
         assertEquals(22, value.get(Calendar.DAY_OF_MONTH));


### PR DESCRIPTION
This fix will work only with Java 8 and above
1. Allow indenting time zone for **java.util.Calendar** during JSON string parse
2. Specified java 8 version within pom due to **java.time** dependencies
